### PR TITLE
Add pattern alias for format validation and string regex support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+**Setup:**
+```bash
+mix deps.get              # Install dependencies
+```
+
+**Testing:**
+```bash
+mix test                  # Run all tests
+mix test test/valdi_test.exs  # Run specific test file
+mix coveralls             # Run tests with coverage
+mix coveralls.html        # Generate HTML coverage report
+```
+
+**Code Quality:**
+```bash
+mix format                # Format code according to .formatter.exs
+mix docs                  # Generate documentation
+```
+
+**Build:**
+```bash
+mix compile               # Compile the project
+```
+
+## Project Architecture
+
+**Valdi** is an Elixir data validation library that provides comprehensive validation functions for different data types and structures.
+
+### Core Module Structure
+
+The main validation logic is contained in a single module `Valdi` (lib/valdi.ex) with these key functions:
+
+- **Main validation functions:**
+  - `validate/2` - Main validation function that accepts value and list of validators
+  - `validate_list/2` - Validates each item in a list against given validators
+  - `validate_map/2` - Validates map values against a validation specification
+
+- **Individual validators:**
+  - `validate_type/2` - Type checking (supports built-in types, structs, arrays)
+  - `validate_required/2` - Required field validation
+  - `validate_number/2` - Number range validation (min/max/equal_to/greater_than/less_than)
+  - `validate_decimal/2` - Decimal number validation using Decimal library
+  - `validate_length/2` - Length validation for strings, lists, maps, tuples
+  - `validate_format/2` - Regex pattern matching for strings (also accessible via `pattern` alias)
+  - `validate_inclusion/2` & `validate_exclusion/2` - Value inclusion/exclusion in enumerables
+  - `validate_each_item/2` - Applies validation to each array element
+
+### Validation Flow
+
+1. `validate/2` calls `prepare_validator/1` to prioritize validators (required → type → others)
+2. `do_validate/3` processes validators sequentially, stopping at first error
+3. Individual validator functions return `:ok` or `{:error, message}`
+4. For list/map validation, errors include indexes/keys for failed items
+
+### Supported Types
+
+Built-in types: `:boolean`, `:integer`, `:float`, `:number`, `:string`/`:binary`, `:tuple`, `:array`/`:list`, `:atom`, `:function`, `:map`, `:keyword`, `:decimal`, `:date`, `:time`, `:datetime`, `:naive_datetime`, `:utc_datetime`
+
+Extended types: struct modules (e.g., `User`), `{:array, type}` for typed arrays
+
+### Testing
+
+The test suite in test/valdi_test.exs provides comprehensive coverage with parameterized tests for different validation scenarios. Tests use ExUnit with doctest for embedded examples.

--- a/test/valdi_test.exs
+++ b/test/valdi_test.exs
@@ -108,6 +108,38 @@ defmodule ValdiTest do
              Valdi.validate(10, type: :integer, format: ~r/year:\s\d{4}/)
   end
 
+  test "validate pattern with match string should ok" do
+    assert :ok = Valdi.validate("year: 1999", type: :string, pattern: ~r/year:\s\d{4}/)
+  end
+
+  test "validate pattern with not match string should error" do
+    assert {:error, "does not match format"} =
+             Valdi.validate("", type: :string, pattern: ~r/year:\s\d{4}/)
+  end
+
+  test "validate pattern with number should error" do
+    assert {:error, "format check only support string"} =
+             Valdi.validate(10, type: :integer, pattern: ~r/year:\s\d{4}/)
+  end
+
+  test "validate format with string pattern should ok" do
+    assert :ok = Valdi.validate("hello world", type: :string, format: "h.*d")
+  end
+
+  test "validate format with string pattern not match should error" do
+    assert {:error, "does not match format"} =
+             Valdi.validate("hello", type: :string, format: "\\d+")
+  end
+
+  test "validate format with invalid string pattern should error" do
+    assert {:error, "invalid regex pattern"} =
+             Valdi.validate("hello", type: :string, format: "[")
+  end
+
+  test "validate pattern with string pattern should ok" do
+    assert :ok = Valdi.validate("test123", type: :string, pattern: "test\\d+")
+  end
+
   @number_tests [
     [:equal_to, 10, 10, :ok],
     [:equal_to, 10, 11, :error],


### PR DESCRIPTION
- Add 'pattern' as alias for 'format' validator
- Support string regex patterns in validate_format function
- Add comprehensive tests for pattern alias and string regex
- Update documentation to reflect new functionality
- Add CLAUDE.md for future development guidance

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Introduce a `pattern` alias for the existing `format` validator, add support for string-based regex patterns in format validation, and update tests and documentation to cover the new functionality.

New Features:
- Add `pattern` option as an alias for the `format` validator
- Support passing regex patterns as strings to `validate_format/2`

Documentation:
- Update inline documentation to describe the `pattern` option and string regex support
- Add `CLAUDE.md` to provide development and contribution guidance

Tests:
- Add tests for the `pattern` alias and for string-based regex pattern handling, including success, mismatch, and invalid pattern cases