### PR TITLE
Bump decimal to ~> 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Valdi.MixProject do
     [
       {:ex_doc, "~> 0.30", only: :dev, runtime: false},
       {:excoveralls, "~> 0.18", only: :test},
-      {:decimal, "~> 2.1"}
+      {:decimal, "~> 3.0"}
     ]
   end
 end


### PR DESCRIPTION
First off, thanks for valdi! It's been a really useful little library for us at Wenia.

## Description

Bumps the `decimal` dependency to `~> 3.0`. 

The recent [CVE-2026-32686](https://nvd.nist.gov/vuln/detail/CVE-2026-32686) report confirms `decimal` needs to be upgraded. Pinning to `~> 3.0` makes sure downstream users get that change.

## Note

Decimal requires [Elixir `~> 1.12`](https://github.com/ericmj/decimal/blob/c273bb4940ecb6aa3971358a6ffe47ed58277725/mix.exs#L11) and valdi's CI runs on elixir 1.10.3, happy to follow up on this if we need a CI Bump, Just let me know.

I think this is a breaking change for downstream users on `decimal ~> 2.0`. You'll probable need a 0.7.0 release.

Tests were verified locally.

Shoutout to @estebanz01 for spotting this one for me 🙏

## Summary by Sourcery

Build:
- Bump the decimal library dependency from ~> 2.1 to ~> 3.0 in mix.exs.